### PR TITLE
Added search games functionality on the home screen

### DIFF
--- a/lib/screens/games_list_screen.dart
+++ b/lib/screens/games_list_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:facebook_audience_network/facebook_audience_network.dart';
 import 'package:in_app_update/in_app_update.dart';
+import 'package:web_display/widgets/search_widget.dart';
 import '../models/ad_helper.dart';
 import '../widgets/no_internet.dart';
 import '../models/connectivity.dart' show MyConnectivity;
@@ -22,6 +23,8 @@ class GamesListScreen extends StatefulWidget {
 class _GamesListScreenState extends State<GamesListScreen> {
   Map _source = {ConnectivityResult.none: false};
   MyConnectivity _connectivity = MyConnectivity.instance;
+  List<Game> gamesList = games;
+  String query = '';
 
   @override
   void initState() {
@@ -72,6 +75,33 @@ class _GamesListScreenState extends State<GamesListScreen> {
     super.dispose();
   }
 
+  Widget buildSearch() => SearchWidget(
+        text: query,
+        onSubmitted: filterList,
+        hintText: 'Search',
+        onReset: resetList,
+      );
+
+  void resetList() {
+    setState(() {
+      gamesList = games;
+      this.query = '';
+    });
+  }
+
+  void filterList(String query) {
+    gamesList = games.where((game) {
+      String gameTitle = game.title.toLowerCase();
+      String queryLower = query.toLowerCase();
+
+      return gameTitle.contains(queryLower);
+    }).toList();
+    setState(() {
+      this.gamesList = gamesList;
+      this.query = query;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     print(_updateInfo);
@@ -108,6 +138,7 @@ class _GamesListScreenState extends State<GamesListScreen> {
                         ? InAppUpdate.performImmediateUpdate()
                         : Column(
                             children: [
+                              buildSearch(),
                               Expanded(
                                 child: ListView.builder(
                                   padding: const EdgeInsets.all(5),
@@ -122,17 +153,17 @@ class _GamesListScreenState extends State<GamesListScreen> {
                                         }
                                         Navigator.of(context).push(
                                             MaterialPageRoute(builder: (ctx) {
-                                          return GameScreen(
-                                              games[i].title, games[i].gameUrl);
+                                          return GameScreen(gamesList[i].title,
+                                              gamesList[i].gameUrl);
                                         }));
                                       },
                                       child: ListItem(
-                                        games[i].title,
-                                        games[i].imageUrl,
+                                        gamesList[i].title,
+                                        gamesList[i].imageUrl,
                                       ),
                                     );
                                   },
-                                  itemCount: games.length,
+                                  itemCount: gamesList.length,
                                 ),
                               ),
                               Container(

--- a/lib/screens/games_list_screen.dart
+++ b/lib/screens/games_list_screen.dart
@@ -25,6 +25,7 @@ class _GamesListScreenState extends State<GamesListScreen> {
   MyConnectivity _connectivity = MyConnectivity.instance;
   List<Game> gamesList = games;
   String query = '';
+  bool appBar = true;
 
   @override
   void initState() {
@@ -86,6 +87,7 @@ class _GamesListScreenState extends State<GamesListScreen> {
     setState(() {
       gamesList = games;
       this.query = '';
+      appBar = true;
     });
   }
 
@@ -120,8 +122,19 @@ class _GamesListScreenState extends State<GamesListScreen> {
     print("update: $_updateInfo");
     return Scaffold(
         appBar: AppBar(
-          title: const Text('Arcade Plaza'),
+          title: appBar ? const Text('Arcade Plaza') : buildSearch(),
           centerTitle: true,
+          actions: [
+            appBar
+                ? IconButton(
+                    icon: Icon(Icons.search),
+                    onPressed: () {
+                      setState(() {
+                        appBar = false;
+                      });
+                    })
+                : SizedBox(),
+          ],
         ),
         drawer: MainDrawer(),
         body: DoubleBackToCloseApp(
@@ -138,7 +151,7 @@ class _GamesListScreenState extends State<GamesListScreen> {
                         ? InAppUpdate.performImmediateUpdate()
                         : Column(
                             children: [
-                              buildSearch(),
+                              // buildSearch(),
                               Expanded(
                                 child: ListView.builder(
                                   padding: const EdgeInsets.all(5),

--- a/lib/widgets/search_widget.dart
+++ b/lib/widgets/search_widget.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+class SearchWidget extends StatefulWidget {
+  final String text;
+  final ValueChanged<String> onSubmitted;
+  final String hintText;
+  final Function onReset;
+
+  const SearchWidget({
+    Key key,
+    @required this.text,
+    @required this.onSubmitted,
+    @required this.hintText,
+    @required this.onReset,
+  }) : super(key: key);
+
+  @override
+  _SearchWidgetState createState() => _SearchWidgetState();
+}
+
+class _SearchWidgetState extends State<SearchWidget> {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 60,
+      padding: const EdgeInsets.symmetric(horizontal: 15),
+      child: Center(
+        child: TextField(
+          decoration: InputDecoration(
+            icon: Icon(Icons.search, color: Colors.black),
+            suffixIcon: widget.text.isNotEmpty
+                ? GestureDetector(
+                    child: Icon(Icons.close, color: Colors.black),
+                    onTap: () {
+                      widget.onReset();
+                    },
+                  )
+                : SizedBox(),
+            hintText: widget.hintText,
+          ),
+          cursorColor: Colors.black,
+          onSubmitted: widget.onSubmitted,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/search_widget.dart
+++ b/lib/widgets/search_widget.dart
@@ -23,22 +23,21 @@ class _SearchWidgetState extends State<SearchWidget> {
   Widget build(BuildContext context) {
     return Container(
       height: 60,
-      padding: const EdgeInsets.symmetric(horizontal: 15),
       child: Center(
         child: TextField(
           decoration: InputDecoration(
-            icon: Icon(Icons.search, color: Colors.black),
-            suffixIcon: widget.text.isNotEmpty
-                ? GestureDetector(
-                    child: Icon(Icons.close, color: Colors.black),
-                    onTap: () {
-                      widget.onReset();
-                    },
-                  )
-                : SizedBox(),
+            icon: Icon(Icons.search, color: Colors.white),
+            suffixIcon: GestureDetector(
+              child: Icon(Icons.close, color: Colors.white),
+              onTap: () {
+                widget.onReset();
+              },
+            ),
             hintText: widget.hintText,
+            hintStyle: TextStyle(color: Colors.white),
+            enabledBorder: InputBorder.none,
           ),
-          cursorColor: Colors.black,
+          cursorColor: Colors.white,
           onSubmitted: widget.onSubmitted,
         ),
       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -162,14 +162,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   mime:
     dependency: transitive
     description:
@@ -321,7 +321,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -377,7 +377,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   win32:
     dependency: transitive
     description:
@@ -393,5 +393,5 @@ packages:
     source: hosted
     version: "0.2.0"
 sdks:
-  dart: ">=2.13.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=2.0.0"


### PR DESCRIPTION
I have added the search games functionality on the home screen, the user will now be able to filter through the list of games when he submits on the keyboard and can revert back to scrolling the full list using the cross button on the textfield. I have made separate functions to implement the search bar. You may style the textfield any way you want, it is located in lib/widgets/search_widget.dart and the functions to filter the list are present in lib/screens/games_list_screen.dart.